### PR TITLE
Added the ability to filter /api/states by using /api/states?populationRange=val1,val2

### DIFF
--- a/src/main/java/edu/northeastern/truthtree/ApplicationConfig.java
+++ b/src/main/java/edu/northeastern/truthtree/ApplicationConfig.java
@@ -1,8 +1,5 @@
 package edu.northeastern.truthtree;
 
-import edu.northeastern.truthtree.adapter.timerange.ITimeRangeAdapter;
-import edu.northeastern.truthtree.adapter.timerange.TimeRangeDBAdapter;
-import edu.northeastern.truthtree.adapter.timerange.TimeRangeMockAdapter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +12,9 @@ import edu.northeastern.truthtree.adapter.basicInfo.IBasicInfoAdapter;
 import edu.northeastern.truthtree.adapter.collections.CollectionsDBAdapter;
 import edu.northeastern.truthtree.adapter.collections.CollectionsMockAdapter;
 import edu.northeastern.truthtree.adapter.collections.ICollectionsAdapter;
+import edu.northeastern.truthtree.adapter.timerange.ITimeRangeAdapter;
+import edu.northeastern.truthtree.adapter.timerange.TimeRangeDBAdapter;
+import edu.northeastern.truthtree.adapter.timerange.TimeRangeMockAdapter;
 
 @Configuration
 public class ApplicationConfig {

--- a/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/BasicInfoDBAdapter.java
+++ b/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/BasicInfoDBAdapter.java
@@ -20,6 +20,20 @@ public class BasicInfoDBAdapter implements IBasicInfoAdapter {
     return URLUtil.readJSONFromURL(STATES_URL);
   }
 
+
+  /**
+   * Gets the basic states info from STATES_URL that have a population betwee startValue and
+   * endValue.
+   *
+   * @param startValue The value that all wanted values will be greater than or equal to.
+   * @param endValue   The value that all wanted values will be less than or equal to.
+   * @return JSONArray that contains states that are within the provided range.
+   */
+  @Override
+  public JSONArray getBasicStatesPopulationRange(int startValue, int endValue) {
+    return null;
+  }
+
   /**
    * Gets the basic states info from the CITIES_URL
    *
@@ -41,5 +55,4 @@ public class BasicInfoDBAdapter implements IBasicInfoAdapter {
 
     return URLUtil.readJSONFromURL(COUNTIES_URL);
   }
-
 }

--- a/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/BasicInfoMockAdapter.java
+++ b/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/BasicInfoMockAdapter.java
@@ -8,6 +8,7 @@ public class BasicInfoMockAdapter implements IBasicInfoAdapter {
 	private static final String STATES_FILE_PATH = "src/main/resources/States.json";
 	private static final String CITIES_FILE_PATH = "src/main/resources/Cities.json";
 	private static final String COUNTIES_FILE_PATH = "src/main/resources/Counties.json";
+	private static final String POPULATION_KEY = "population";
 
 	/**
 	 * Reads a JSON file containing basic state information.
@@ -18,6 +19,13 @@ public class BasicInfoMockAdapter implements IBasicInfoAdapter {
 	public JSONArray getBasicStatesInfo() {
 
 		return JSONUtil.readJSONFile(STATES_FILE_PATH);
+	}
+
+	@Override
+	public JSONArray getBasicStatesPopulationRange(int startValue, int endValue) {
+		JSONArray jsonArray = JSONUtil.readJSONFile(STATES_FILE_PATH);
+
+		return JSONUtil.filterJSON(jsonArray, POPULATION_KEY, startValue, endValue);
 	}
 
 	/**

--- a/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/IBasicInfoAdapter.java
+++ b/src/main/java/edu/northeastern/truthtree/adapter/basicInfo/IBasicInfoAdapter.java
@@ -4,9 +4,34 @@ import org.json.simple.JSONArray;
 
 public interface IBasicInfoAdapter {
 
+	/**
+	 * Gets the basic States information.
+	 *
+	 * @return basic States information as a JSONArray.
+	 */
 	JSONArray getBasicStatesInfo();
 
+	/**
+	 * Gets the basic States information for states that have a population within startValue and
+	 * endValue, inclusive.
+	 *
+	 * @param startValue The value that all wanted values will be greater than or equal to.
+	 * @param endValue   The value that all wanted values will be less than or equal to.
+	 * @return JSONArray that contains states that are within the provided range.
+	 */
+	JSONArray getBasicStatesPopulationRange(int startValue, int endValue);
+
+	/**
+	 * Gets the basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray.
+	 */
 	JSONArray getBasicCitiesInfo();
 
+	/**
+	 * Gets the basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray.
+	 */
 	JSONArray getBasicCountiesInfo();
 }

--- a/src/main/java/edu/northeastern/truthtree/adapter/utilities/JSONUtil.java
+++ b/src/main/java/edu/northeastern/truthtree/adapter/utilities/JSONUtil.java
@@ -72,4 +72,24 @@ public class JSONUtil {
 
     return jsonObject;
   }
+
+  public static JSONArray filterJSON(JSONArray jsonArray, String JSONKey, int startValue,
+                                     int endValue) {
+
+    JSONArray filteredArray = new JSONArray();
+
+    for (int i = 0; i < jsonArray.size(); i++) {
+      JSONObject object = (JSONObject) jsonArray.get(i);
+
+      String valueString = (String) object.get(JSONKey);
+      valueString = valueString.replaceAll(",", "");
+      int valueInt = Integer.parseInt(valueString);
+
+      if (valueInt >= startValue && valueInt <= endValue) {
+        filteredArray.add(object);
+      }
+    }
+
+    return filteredArray;
+  }
 }

--- a/src/main/java/edu/northeastern/truthtree/controller/basicInfo/BasicInfo.java
+++ b/src/main/java/edu/northeastern/truthtree/controller/basicInfo/BasicInfo.java
@@ -4,6 +4,7 @@ import org.json.simple.JSONArray;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.northeastern.truthtree.service.basicInfo.IBasicInfoService;
@@ -13,11 +14,21 @@ import edu.northeastern.truthtree.service.basicInfo.IBasicInfoService;
 public class BasicInfo implements IBasicInfo {
 	private IBasicInfoService service;
 
+	private static final String POPULATION_ERROR = "ERROR: The supplied parameters were incorrect. " +
+			"Please provide exactly two values in the format /api/states?populationRange=startValue," +
+			"endValue";
+	static final String POPULATION_RANGE = "populationRange";
+
 	@Autowired
 	public BasicInfo(IBasicInfoService service) {
 		this.service = service;
 	}
 
+	/**
+	 * Gets basic States information.
+	 *
+	 * @return basic States information as a JSONArray string.
+	 */
 	@Override
 	@RequestMapping("/api/states")
 	public String getBasicStatesInfo() {
@@ -25,6 +36,30 @@ public class BasicInfo implements IBasicInfo {
 		return response.toJSONString();
 	}
 
+	/**
+	 * Gets basic States information for states that have a population within startValue and
+	 * endValue, inclusive.
+	 *
+	 * @param range The start and end values that will be used to filter the states returned.
+	 * @return JSONArray that contains states that are within the provided range.
+	 */
+	@Override
+	@RequestMapping(value = "/api/states", params = POPULATION_RANGE)
+	public String getBasicStatesPopulationRange(@RequestParam(POPULATION_RANGE) int[] range) {
+
+		if (range.length == 2) {
+			JSONArray response = this.service.getBasicStatesPopulationRange(range[0], range[1]);
+			return response.toJSONString();
+		}
+
+		return POPULATION_ERROR;
+	}
+
+	/**
+	 * Gets basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray string.
+	 */
 	@Override
 	@RequestMapping("/api/cities")
 	public String getBasicCitiesInfo() {
@@ -32,6 +67,11 @@ public class BasicInfo implements IBasicInfo {
 		return response.toJSONString();
 	}
 
+	/**
+	 * Gets basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray string.
+	 */
 	@Override
 	@RequestMapping("/api/counties")
 	public String getBasicCountiesInfo() {

--- a/src/main/java/edu/northeastern/truthtree/controller/basicInfo/IBasicInfo.java
+++ b/src/main/java/edu/northeastern/truthtree/controller/basicInfo/IBasicInfo.java
@@ -1,9 +1,38 @@
 package edu.northeastern.truthtree.controller.basicInfo;
 
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static edu.northeastern.truthtree.controller.basicInfo.BasicInfo.POPULATION_RANGE;
+
 public interface IBasicInfo {
+
+	/**
+	 * Gets basic States information.
+	 *
+	 * @return basic States information as a JSONArray string.
+	 */
 	String getBasicStatesInfo();
 
+	/**
+	 * Gets basic States information for states that have a population within range, inclusive.
+	 *
+	 * @param range The population range that will be used to filter the states returned. Must be in
+	 *              the format =val1,val2
+	 * @return JSONArray that contains states that are within the provided range.
+	 */
+	String getBasicStatesPopulationRange(@RequestParam(POPULATION_RANGE) int[] range);
+
+	/**
+	 * Gets basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray string.
+	 */
 	String getBasicCitiesInfo();
 
+	/**
+	 * Gets basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray string.
+	 */
 	String getBasicCountiesInfo();
 }

--- a/src/main/java/edu/northeastern/truthtree/service/basicInfo/BasicInfoService.java
+++ b/src/main/java/edu/northeastern/truthtree/service/basicInfo/BasicInfoService.java
@@ -21,6 +21,11 @@ public class BasicInfoService implements IBasicInfoService {
 	}
 
 	@Override
+	public JSONArray getBasicStatesPopulationRange(int startValue, int endValue) {
+		return this.adapter.getBasicStatesPopulationRange(startValue, endValue);
+	}
+
+	@Override
 	public JSONArray getBasicCitiesInfo() {
 		return this.adapter.getBasicCitiesInfo();
 	}

--- a/src/main/java/edu/northeastern/truthtree/service/basicInfo/IBasicInfoService.java
+++ b/src/main/java/edu/northeastern/truthtree/service/basicInfo/IBasicInfoService.java
@@ -3,9 +3,34 @@ package edu.northeastern.truthtree.service.basicInfo;
 import org.json.simple.JSONArray;
 
 public interface IBasicInfoService {
+	/**
+	 * Gets the basic States information.
+	 *
+	 * @return basic States information as a JSONArray.
+	 */
 	JSONArray getBasicStatesInfo();
 
+	/**
+	 * Gets the basic States information for states that have a population within startValue and
+	 * endValue, inclusive.
+	 *
+	 * @param startValue The value that all wanted values will be greater than or equal to.
+	 * @param endValue   The value that all wanted values will be less than or equal to.
+	 * @return JSONArray that contains states that are within the provided range.
+	 */
+	JSONArray getBasicStatesPopulationRange(int startValue, int endValue);
+
+	/**
+	 * Gets the basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray.
+	 */
 	JSONArray getBasicCitiesInfo();
 
+	/**
+	 * Gets the basic Cities information.
+	 *
+	 * @return basic Cities information as a JSONArray.
+	 */
 	JSONArray getBasicCountiesInfo();
 }

--- a/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -331,7 +331,7 @@
     <h5>Request URL:</h5>
     <pre class="prettyprint http"><code class="language-http">/api/states</code></pre>
     <br>
-    <pre class="prettyprint http"><code class="language-http">/api/states?populationRange[startValue, endValue]</code></pre>
+    <pre class="prettyprint http"><code class="language-http">/api/states?populationRange=startValue,endValue</code></pre>
     <br>
     <pre class="prettyprint http"><code class="language-http">/api/counties</code></pre>
     <br>
@@ -361,25 +361,31 @@
 ]</code></pre>
 </div>
 <div class="basicInfoStatesCode codeBlock">
-    <pre class="prettyprint">/api/states?populationRange[4000000,5000000]
+    <pre class="prettyprint">/api/states?populationRange=4000000,5000000
 <code class="language-json">[
     {
-        "state_code": 1,
         "name": "ALABAMA",
+        "state_code": 1,
         "abbreviation": "AL"
         "population": "4,887,871"
     },
     {
-        "state_code": 19,
         "name": "LOUISIANA",
+        "state_code": 19,
         "abbreviation": "KY"
         "population": "4,659,978"
     },
     {
-        "state_code": 17,
         "name": "KENTUCKY",
+        "state_code": 17,
         "abbreviation": "AZ"
         "population": "4,468,402"
+    },
+    {
+        "name": "OREGON",
+        "state_code": 38,
+        "abbreviation": "OR",
+        "population": "4,190,713"
     }
 ]</code></pre>
 </div>
@@ -438,7 +444,6 @@
     parameters can be used to find desired result.
 </div>
 <div class="text-block text-body">
-    <h5>Request URL:</h5>
     <table class="table table-striped">
         <thead>
         <tr>


### PR DESCRIPTION
1. Added the ability to filter the returned states by querying /api/states?populationRange=val1,val2
a) Example: /api/states?populationRange=4000000,5000000

2. Updated index.jsp to reflect the required format.
